### PR TITLE
feat(fixbugs): correção de dependências

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,37 @@
 {
+  "name": "agendaglow",
+  "version": "1.0.0",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
   "dependencies": {
-    "@react-native-picker/picker": "^2.11.4",
-    "expo": "^54.0.22"
+    "@expo/vector-icons": "^15.0.3",
+    "@react-native-async-storage/async-storage": "^2.2.0",
+   "@react-native-picker/picker": "^2.11.1",
+    "@react-navigation/bottom-tabs": "^7.8.4",
+    "@react-navigation/native": "^7.1.19",
+    "@react-navigation/native-stack": "^7.6.2",
+    "@react-navigation/stack": "^7.6.2",
+    "expo": "~54.0.22",
+    "expo-auth-session": "~7.0.8",
+    "expo-crypto": "~15.0.7",
+    "expo-font": "~14.0.9",
+    "expo-splash-screen": "~31.0.10",
+    "expo-status-bar": "~3.0.8",
+    "expo-web-browser": "^15.0.9",
+    "firebase": "^12.5.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "react-native": "0.81.5",
+    "react-native-modal-datetime-picker": "^17.0.0",
+    "react-native-paper": "^5.14.5",
+    "react-native-safe-area-context": "~5.6.0",
+    "react-native-screens": "~4.16.0",
+    "react-native-web": "^0.21.0"
   }
 }


### PR DESCRIPTION
Já havia sido feita a correção, porém após algum merge, o package.json subiu com poucos dados, observe abaixo:
{
  "dependencies": {
    "@react-native-picker/picker": "^2.11.4",
    "expo": "^54.0.22"
  }
}